### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ EasyJSWebView is a library that allows you to do the same in Objective-C. Downlo
 
 You may find the sample project [here](https://github.com/dukeland/EasyJSWebViewSample).
 
-###Some code to demonstrate
+### Some code to demonstrate
 So basically what you need to do is create a class like this.
 
 ```obj-c
@@ -70,7 +70,7 @@ Simple, huh!?
 
 **Try it now!!!**
 
-###Some simple facts
+### Some simple facts
 * NSInvocation does not live peacefully with ARC. This library is thus a non-ARC library.
 * It supports only NSString* for message passing now.
 * We are Dukeland from Hong Kong! A group of IT-holic guys


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
